### PR TITLE
expand possible choices of link

### DIFF
--- a/R/te-formulas.R
+++ b/R/te-formulas.R
@@ -49,22 +49,24 @@ te_fit_glm <- function(parsedmodel) {
 
   assigned <- 0
 
-  if (family == "gaussian" && link == "identity") {
+  if (link == "identity") {
     assigned <- 1
   }
 
-  if (family == "binomial" && link == "logit") {
+  if (link == "logit") {
     assigned <- 1
     fit <- expr(1 - 1 / (1 + exp(!! fit)))
   }
-
-  if (assigned == 0) {
-    stop("Combination of family and link are not supported")
-  }
-
+  
+  
   if (link == "log") {
     assigned <- 1
     fit <- expr(exp(!! fit))
+  }
+
+
+  if (assigned == 0) {
+    stop("Combination of family and link are not supported")
   }
 
   fit


### PR DESCRIPTION
Two changes: 
- move the test for log link above the error message so it works
- drop the test for family. If the user has supplied a fitted glm then it must be a legitimate combination of link and family, and the family doesn't matter for point prediction.  You still do need the test for family in `te_interval_glm`
